### PR TITLE
Minor changes

### DIFF
--- a/src/brain/src/brain.cpp
+++ b/src/brain/src/brain.cpp
@@ -583,9 +583,8 @@ vector<GameObject> Brain::getGameObjects(const vision_interface::msg::Detections
 {
     vector<GameObject> res;
 
-    auto timestamp = detections.header.stamp;
-
-    rclcpp::Time timePoint(timestamp.sec, timestamp.nanosec);
+    // Use current ROS system time instead of camera timestamp
+    rclcpp::Time timePoint = get_clock()->now();
 
     for (int i = 0; i < detections.detected_objects.size(); i++)
     {

--- a/src/brain/src/brain_tree.cpp
+++ b/src/brain/src/brain_tree.cpp
@@ -73,7 +73,7 @@ void BrainTree::initEntry()
     setEntry<bool>("gc_is_under_penalty", false);
 
     setEntry<bool>("treat_person_as_robot", false);
-    setEntry<int>("control_state", 0);
+    setEntry<int>("control_state", 3);  // (ACTION mode)
     setEntry<bool>("B_pressed", false);
 
     // fallRecovery相关


### PR DESCRIPTION
This PR does the following: 

- Defaults to ACTION mode to avoid needing joystick
- Use current ROS system time instead of camera timestamp for detections